### PR TITLE
Removed 8 unnecessary stubbings in CommunicationtTestMocker

### DIFF
--- a/src/test/java/test/bftsmart/communication/server/CommunicationtTestMocker.java
+++ b/src/test/java/test/bftsmart/communication/server/CommunicationtTestMocker.java
@@ -19,26 +19,17 @@ public class CommunicationtTestMocker {
 
 	public static ViewTopology mockTopology(int currentId, int[] processIds) {
 		ReplicaConfiguration conf = mockConfiguration(currentId, processIds);
-		
+
 		return mockTopology(currentId, processIds, conf);
 	}
-	
+
 	public static ViewTopology mockTopology(int currentId, int[] processIds, ReplicaConfiguration conf) {
 		ViewTopology topology = Mockito.mock(ViewTopology.class);
 		when(topology.getCurrentProcessId()).thenReturn(currentId);
 		when(topology.getCurrentViewProcesses()).thenReturn(processIds);
 		when(topology.isInCurrentView()).thenReturn(contains(currentId, processIds));
-		when(topology.isCurrentViewMember(anyInt())).thenAnswer(new Answer<Boolean>() {
+		when(topology.getStaticConf()).thenReturn(conf);
 
-			@Override
-			public Boolean answer(InvocationOnMock invocation) throws Throwable {
-				int id = invocation.getArgument(0);
-				return contains(id, processIds);
-			}
-		});
-		
-        when(topology.getStaticConf()).thenReturn(conf);
-        
 		return topology;
 	}
 
@@ -63,17 +54,10 @@ public class CommunicationtTestMocker {
 
 	public static ReplicaConfiguration mockConfiguration(int currentId, int[] processIds) {
 		ReplicaConfiguration conf = Mockito.mock(ReplicaConfiguration.class);
-		when(conf.getProcessId()).thenReturn(currentId);
-		when(conf.getInitialView()).thenReturn(processIds);
 		when(conf.getInQueueSize()).thenReturn(100000);
-		when(conf.getOutQueueSize()).thenReturn(100000);
-		when(conf.getSendRetryCount()).thenReturn(10);
-
 		try {
 			DefaultRSAKeyLoader defaultRSAKeyLoader = new DefaultRSAKeyLoader();
-			when(conf.getRSAPrivateKey()).thenReturn(defaultRSAKeyLoader.loadPrivateKey(currentId));
-			when(conf.getRSAPublicKey(currentId)).thenReturn(defaultRSAKeyLoader.loadPublicKey(currentId));
-		} catch (Exception e) {
+			} catch (Exception e) {
 			throw new IllegalStateException(e.getMessage(), e);
 		}
 		return conf;
@@ -89,15 +73,15 @@ public class CommunicationtTestMocker {
 			hosts.add(processIds[i], "localhost", port, 0);
 		}
 		TOMConfiguration conf = new TOMConfiguration(currentId, new Properties(), hosts);
-		
+
 		conf = Mockito.spy(conf);
-		
+
 		when(conf.getProcessId()).thenReturn(currentId);
 		when(conf.getInQueueSize()).thenReturn(100000);
 		when(conf.getOutQueueSize()).thenReturn(100000);
-		
+
 		return conf;
-		
+
 //		ReplicaConfiguration conf = mockConfiguration(currentId, processIds);
 //
 //		when(conf.getServerToServerPort(anyInt())).thenAnswer(new Answer<Integer>() {
@@ -123,6 +107,18 @@ public class CommunicationtTestMocker {
 			}
 		}
 		return false;
+	}
+
+	public static ReplicaTopology mockTopologyWithTCP2(int currentId, int[] processIds, int[] ports) {
+		ReplicaTopology topology = Mockito.mock(ReplicaTopology.class);
+		when(topology.getCurrentProcessId()).thenReturn(currentId);
+		when(topology.getCurrentViewProcesses()).thenReturn(processIds);
+		when(topology.isInCurrentView()).thenReturn(contains(currentId, processIds));
+
+		ReplicaConfiguration conf = mockDefaultConfiguration(currentId, processIds, ports);
+		when(topology.getStaticConf()).thenReturn(conf);
+
+		return topology;
 	}
 
 }

--- a/src/test/java/test/bftsmart/communication/server/ServerCommunicationLayerTest.java
+++ b/src/test/java/test/bftsmart/communication/server/ServerCommunicationLayerTest.java
@@ -242,7 +242,7 @@ public class ServerCommunicationLayerTest {
 		int[] viewProcessIds = { 0, 1};
 		int[] ports = { 14100, 14110};
 
-		CommunicationLayer[] servers = prepareNettyNodes(realmName, viewProcessIds, ports);
+		CommunicationLayer[] servers = prepareNettyNodes2(realmName, viewProcessIds, ports);
 		MessageCounter[] counters = prepareMessageCounters(servers);
 
 		for (CommunicationLayer server : servers) {
@@ -272,7 +272,7 @@ public class ServerCommunicationLayerTest {
 		int[] viewProcessIds = { 0, 1, 2, 3 };
 		int[] ports = { 15100, 15110, 15120, 15130 };
 
-		CommunicationLayer[] servers = prepareNettyNodes(realmName, viewProcessIds, ports);
+		CommunicationLayer[] servers = prepareNettyNodes2(realmName, viewProcessIds, ports);
 		MessageCounter[] counters = prepareMessageCounters(servers);
 
 		for (CommunicationLayer srv : servers) {
@@ -433,6 +433,16 @@ public class ServerCommunicationLayerTest {
 				assertArrayEquals(expected, actual);
 			}
 		}
+	}
+
+	private CommunicationLayer[] prepareNettyNodes2(String realmName, int[] viewProcessIds, int[] ports) {
+		CommunicationLayer[] comLayers = new CommunicationLayer[viewProcessIds.length];
+		for (int i = 0; i < comLayers.length; i++) {
+			ReplicaTopology topology = CommunicationtTestMocker.mockTopologyWithTCP2(viewProcessIds[i], viewProcessIds, ports);
+			CommunicationLayer comLayer = new NettyServerCommunicationLayer(realmName, topology);
+			comLayers[i] = comLayer;
+		}
+		return comLayers;
 	}
 
 }


### PR DESCRIPTION
In our analysis of the project, we observed that the 

1) `CommunicationtTestMocker.mockTopology` contains 1 stubbing which is created but never executed. 
2) `CommunicationtTestMocker.mockConfiguration`  contains 6 stubbings which are created but never executed. 
3) `CommunicationtTestMocker.mockTopologyWithTCP` contains 1 stubbing (stubbed `CurrentViewMember`method)  which is created but never executed in 2 tests: `ServerCommunicationLayerTest.testDoubleNettyNodes`  and `ServerCommunicationLayerTest.testNettyNodesNetwork` 


Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbing.